### PR TITLE
No babel-runtime.

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,3 @@
 {
-  "stage": 0,
-  "optional": [
-    "runtime"
-  ]
+  "stage": 0
 }

--- a/dist/channel.js
+++ b/dist/channel.js
@@ -1,27 +1,18 @@
-'use strict';
-
-var _createClass = require('babel-runtime/helpers/create-class')['default'];
-
-var _classCallCheck = require('babel-runtime/helpers/class-call-check')['default'];
-
-var _toConsumableArray = require('babel-runtime/helpers/to-consumable-array')['default'];
-
-var _slicedToArray = require('babel-runtime/helpers/sliced-to-array')['default'];
-
-var _Symbol = require('babel-runtime/core-js/symbol')['default'];
-
-var _regeneratorRuntime = require('babel-runtime/regenerator')['default'];
-
-var _Promise = require('babel-runtime/core-js/promise')['default'];
-
-var _getIterator = require('babel-runtime/core-js/get-iterator')['default'];
-
-var _Array$entries = require('babel-runtime/core-js/array/entries')['default'];
+"use strict";
 
 Object.defineProperty(exports, '__esModule', {
     value: true
 });
+
+var _slicedToArray = (function () { function sliceIterator(arr, i) { var _arr = []; var _n = true; var _d = false; var _e = undefined; try { for (var _i = arr[Symbol.iterator](), _s; !(_n = (_s = _i.next()).done); _n = true) { _arr.push(_s.value); if (i && _arr.length === i) break; } } catch (err) { _d = true; _e = err; } finally { try { if (!_n && _i['return']) _i['return'](); } finally { if (_d) throw _e; } } return _arr; } return function (arr, i) { if (Array.isArray(arr)) { return arr; } else if (Symbol.iterator in Object(arr)) { return sliceIterator(arr, i); } else { throw new TypeError('Invalid attempt to destructure non-iterable instance'); } }; })();
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
 exports.timeout = timeout;
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
 
 var _dataStructuresJs = require('./data-structures.js');
 
@@ -35,25 +26,25 @@ var log = console.log.bind(console); // eslint-disable-line no-unused-vars
     ENDED  : The Channel is closed, and no longer has values to be taken.
 */
 var STATES = {
-    OPEN: _Symbol('channel_open'),
-    CLOSED: _Symbol('channel_closed'),
-    ENDED: _Symbol('channel_ended')
+    OPEN: Symbol('channel_open'),
+    CLOSED: Symbol('channel_closed'),
+    ENDED: Symbol('channel_ended')
 };
 
 exports.STATES = STATES;
 var ACTIONS = {
     // channel has just been closed, and has no more values to take
-    DONE: _Symbol('channel_done'),
-    CANCEL: _Symbol('channel_cancel')
+    DONE: Symbol('channel_done'),
+    CANCEL: Symbol('channel_cancel')
 };
 
 exports.ACTIONS = ACTIONS;
-var SLIDER = _Symbol('channel_slider');
-var STATE = _Symbol('channel_state');
-var SHOULD_CLOSE = _Symbol('channel_should_close');
-var IS_CONSUMING = _Symbol('channel_consuming');
-var IS_FLUSHING = _Symbol('channel_flushing');
-var IS_SLIDING = _Symbol('channel_sliding');
+var SLIDER = Symbol('channel_slider');
+var STATE = Symbol('channel_state');
+var SHOULD_CLOSE = Symbol('channel_should_close');
+var IS_CONSUMING = Symbol('channel_consuming');
+var IS_FLUSHING = Symbol('channel_flushing');
+var IS_SLIDING = Symbol('channel_sliding');
 
 /*
     Error expose method to assist with ensuring
@@ -85,7 +76,7 @@ function finish(ch) {
 */
 function flush(ch) {
     var take, takes;
-    return _regeneratorRuntime.async(function flush$(context$1$0) {
+    return regeneratorRuntime.async(function flush$(context$1$0) {
         while (1) switch (context$1$0.prev = context$1$0.next) {
             case 0:
                 if (ch.empty()) {
@@ -110,7 +101,7 @@ function flush(ch) {
                 while (take = ch.takes.shift()) // eslint-disable-line no-cond-assign
                 takes.push(take(ACTIONS.DONE));
                 context$1$0.next = 9;
-                return _regeneratorRuntime.awrap(_Promise.all(takes));
+                return regeneratorRuntime.awrap(Promise.all(takes));
 
             case 9:
                 if (!ch[IS_CONSUMING]) finish(ch);
@@ -131,18 +122,18 @@ function wrap(val, transform, resolve) {
         if (transform.length === 1) {
             wrapped = function callee$1$0() {
                 var transformed, actual;
-                return _regeneratorRuntime.async(function callee$1$0$(context$2$0) {
+                return regeneratorRuntime.async(function callee$1$0$(context$2$0) {
                     while (1) switch (context$2$0.prev = context$2$0.next) {
                         case 0:
                             transformed = transform(val);
 
-                            if (!(transformed instanceof _Promise)) {
+                            if (!(transformed instanceof Promise)) {
                                 context$2$0.next = 6;
                                 break;
                             }
 
                             context$2$0.next = 4;
-                            return _regeneratorRuntime.awrap(transformed);
+                            return regeneratorRuntime.awrap(transformed);
 
                         case 4:
                             actual = context$2$0.sent;
@@ -162,11 +153,11 @@ function wrap(val, transform, resolve) {
                 var accepted = new _dataStructuresJs.List();
                 if (transform.length === 2) {
                     wrapped = function callee$2$0() {
-                        return _regeneratorRuntime.async(function callee$2$0$(context$3$0) {
+                        return regeneratorRuntime.async(function callee$2$0$(context$3$0) {
                             while (1) switch (context$3$0.prev = context$3$0.next) {
                                 case 0:
                                     context$3$0.next = 2;
-                                    return _regeneratorRuntime.awrap(transform(val, function (acc) {
+                                    return regeneratorRuntime.awrap(transform(val, function (acc) {
                                         if (typeof acc !== 'undefined') accepted.push(acc);
                                     }));
 
@@ -181,7 +172,7 @@ function wrap(val, transform, resolve) {
                     };
                 } else /* transform.length === 3 */{
                         wrapped = function () {
-                            return new _Promise(function (res) {
+                            return new Promise(function (res) {
                                 transform(val, function (acc) {
                                     if (typeof acc !== 'undefined') accepted.push(acc);
                                 }, function () {
@@ -194,7 +185,7 @@ function wrap(val, transform, resolve) {
         }
     } else {
         wrapped = function callee$1$0() {
-            return _regeneratorRuntime.async(function callee$1$0$(context$2$0) {
+            return regeneratorRuntime.async(function callee$1$0$(context$2$0) {
                 while (1) switch (context$2$0.prev = context$2$0.next) {
                     case 0:
                         return context$2$0.abrupt('return', val);
@@ -217,14 +208,14 @@ function wrap(val, transform, resolve) {
 function _bufferedSlide(ch) {
     var _loop, put;
 
-    return _regeneratorRuntime.async(function _bufferedSlide$(context$1$0) {
+    return regeneratorRuntime.async(function _bufferedSlide$(context$1$0) {
         var _this2 = this;
 
         while (1) switch (context$1$0.prev = context$1$0.next) {
             case 0:
                 _loop = function callee$1$0() {
                     var buf, val, take, put;
-                    return _regeneratorRuntime.async(function callee$1$0$(context$2$0) {
+                    return regeneratorRuntime.async(function callee$1$0$(context$2$0) {
                         while (1) switch (context$2$0.prev = context$2$0.next) {
                             case 0:
                                 buf = ch.buf.shift();
@@ -236,7 +227,7 @@ function _bufferedSlide(ch) {
                                 }
 
                                 context$2$0.next = 5;
-                                return _regeneratorRuntime.awrap(buf.wrapped());
+                                return regeneratorRuntime.awrap(buf.wrapped());
 
                             case 5:
                                 val = context$2$0.sent;
@@ -295,10 +286,10 @@ function _bufferedSlide(ch) {
                                                 }
                                         })();
                                     } else {
-                                        take = ch.takes.shift();
+                                            take = ch.takes.shift();
 
-                                        take(val);
-                                    }
+                                            take(val);
+                                        }
                                 }
                                 if (!ch.puts.empty() && !ch.buf.full()) {
                                     put = ch.puts.shift();
@@ -321,7 +312,7 @@ function _bufferedSlide(ch) {
                 }
 
                 context$1$0.next = 4;
-                return _regeneratorRuntime.awrap(_loop());
+                return regeneratorRuntime.awrap(_loop());
 
             case 4:
                 context$1$0.next = 1;
@@ -345,19 +336,19 @@ function _bufferedSlide(ch) {
 function _slide(ch) {
     var _loop2;
 
-    return _regeneratorRuntime.async(function _slide$(context$1$0) {
+    return regeneratorRuntime.async(function _slide$(context$1$0) {
         var _this3 = this;
 
         while (1) switch (context$1$0.prev = context$1$0.next) {
             case 0:
                 _loop2 = function callee$1$0() {
                     var put, val, take;
-                    return _regeneratorRuntime.async(function callee$1$0$(context$2$0) {
+                    return regeneratorRuntime.async(function callee$1$0$(context$2$0) {
                         while (1) switch (context$2$0.prev = context$2$0.next) {
                             case 0:
                                 put = ch.puts.shift();
                                 context$2$0.next = 3;
-                                return _regeneratorRuntime.awrap(put.wrapped());
+                                return regeneratorRuntime.awrap(put.wrapped());
 
                             case 3:
                                 val = context$2$0.sent;
@@ -413,7 +404,7 @@ function _slide(ch) {
                 }
 
                 context$1$0.next = 4;
-                return _regeneratorRuntime.awrap(_loop2());
+                return regeneratorRuntime.awrap(_loop2());
 
             case 4:
                 context$1$0.next = 1;
@@ -433,7 +424,7 @@ function canSlide(ch) {
 function slide(ch) {
     var _ch$puts2;
 
-    return _regeneratorRuntime.async(function slide$(context$1$0) {
+    return regeneratorRuntime.async(function slide$(context$1$0) {
         while (1) switch (context$1$0.prev = context$1$0.next) {
             case 0:
                 if (!ch[IS_SLIDING]) {
@@ -453,7 +444,7 @@ function slide(ch) {
                 }
 
                 context$1$0.next = 6;
-                return _regeneratorRuntime.awrap(ch[SLIDER](ch));
+                return regeneratorRuntime.awrap(ch[SLIDER](ch));
 
             case 6:
                 context$1$0.next = 3;
@@ -466,7 +457,7 @@ function slide(ch) {
                 }
 
                 (_ch$puts2 = ch.puts).unshift.apply(_ch$puts2, _toConsumableArray(ch.tails));
-                ch.tails = new _dataStructuresJs.List();
+                ch.tails = new _dataStructuresJs.List(); // need a way to empty out the list
 
             case 11:
                 if (!canSlide(ch)) {
@@ -475,7 +466,7 @@ function slide(ch) {
                 }
 
                 context$1$0.next = 14;
-                return _regeneratorRuntime.awrap(ch[SLIDER](ch));
+                return regeneratorRuntime.awrap(ch[SLIDER](ch));
 
             case 14:
                 context$1$0.next = 11;
@@ -495,9 +486,9 @@ function slide(ch) {
 }
 
 function timeout() {
-    var delay = arguments[0] === undefined ? 0 : arguments[0];
+    var delay = arguments.length <= 0 || arguments[0] === undefined ? 0 : arguments[0];
 
-    return new _Promise(function (resolve) {
+    return new Promise(function (resolve) {
         setTimeout(resolve, delay);
     });
 }
@@ -539,17 +530,28 @@ var Channel = (function () {
         } else this[SLIDER] = _slide;
     }
 
+    /*
+        A helper constructor which will convert any iterable into a channel,
+        placing all of the iterable's values onto that channel.
+    */
+
     _createClass(Channel, [{
         key: 'close',
+        // we have a timing problem with pipes.. this resolves it, but is hacky.
 
         /*
             Calls Channel.close for `this`, `all`.
         */
         value: function close() {
-            var all = arguments[0] === undefined ? false : arguments[0];
+            var all = arguments.length <= 0 || arguments[0] === undefined ? false : arguments[0];
 
             return Channel.close(this, all);
         }
+
+        /*
+            Determines if a channel
+            has any values left for `take` to use.
+        */
     }, {
         key: 'empty',
 
@@ -559,6 +561,12 @@ var Channel = (function () {
         value: function empty() {
             return Channel.empty(this);
         }
+
+        /*
+            Places a new value onto the provided channel.
+             If the buffer is full, the promise will be pushed
+            onto Channel.puts to be resolved when buffer space is available.
+        */
     }, {
         key: 'put',
 
@@ -568,6 +576,12 @@ var Channel = (function () {
         value: function put(val) {
             return Channel.put(this, val);
         }
+
+        /*
+            Takes the first value from the provided channel.
+             If no value is provided, the promise will be pushed
+            onto Channel.takes to be resolved when a value is available.
+        */
     }, {
         key: 'take',
 
@@ -586,6 +600,11 @@ var Channel = (function () {
         value: function tail(val) {
             return Channel.tail(this, val);
         }
+
+        /*
+            Helper method for putting values onto a channel
+            from a provided producer whenever there is space.
+        */
     }, {
         key: 'produce',
 
@@ -595,6 +614,11 @@ var Channel = (function () {
         value: function produce(producer) {
             return Channel.produce(this, producer);
         }
+
+        /*
+            Helper method for executing a provided consumer
+            each time a channel value is available.
+        */
     }, {
         key: 'consume',
 
@@ -602,10 +626,15 @@ var Channel = (function () {
             Calls Channel.consume for `this`, `consumer`.
         */
         value: function consume() {
-            var consumer = arguments[0] === undefined ? function () {} : arguments[0];
+            var consumer = arguments.length <= 0 || arguments[0] === undefined ? function () {} : arguments[0];
 
             return Channel.consume(this, consumer);
         }
+
+        /*
+            Registers a promise to be resolved
+            when the channel has fully ended.
+        */
     }, {
         key: 'done',
 
@@ -615,6 +644,15 @@ var Channel = (function () {
         value: function done() {
             return Channel.done(this);
         }
+
+        /*
+            Automatically builds a set of channels
+            for the provided function arguments,
+            setting up a pipe from the first channel
+            all the way down to the last channel.
+             Returns references to both
+            the first and the last channel.
+        */
     }, {
         key: 'pipe',
 
@@ -628,6 +666,10 @@ var Channel = (function () {
 
             return Channel.pipe.apply(Channel, [this].concat(channels));
         }
+
+        /*
+            Pipes all provided channels into a new, single destination.
+        */
     }, {
         key: 'merge',
 
@@ -666,37 +708,38 @@ var Channel = (function () {
         get: function get() {
             return this[STATE];
         }
-    }, {
-        key: 'length',
 
         /*
             Gets the length of the channel,
             which is interpreted as the current length of the buffer
             added to any puts which are waiting for space in the buffer.
         */
+    }, {
+        key: 'length',
         get: function get() {
             if (this.buf) return this.buf.length + this.puts.length;
             return this.puts.length;
         }
-    }, {
-        key: 'size',
 
         /*
             Gets the size of the channel,
             which is interpreted as the size of the buffer.
         */
+    }, {
+        key: 'size',
         get: function get() {
             return this.buf ? this.buf.size : undefined;
         }
-    }], [{
-        key: 'from',
 
         /*
-            A helper constructor which will convert any iterable into a channel,
-            placing all of the iterable's values onto that channel.
+            Marks a channel to no longer be writable.
+             Accepts an optional boolean `all`, to signify
+            whether or not to close the entire pipeline.
         */
+    }], [{
+        key: 'from',
         value: function from(iterable) {
-            var keepOpen = arguments[1] === undefined ? false : arguments[1];
+            var keepOpen = arguments.length <= 1 || arguments[1] === undefined ? false : arguments[1];
 
             var arr = [].concat(_toConsumableArray(iterable));
             var ch = new Channel(arr.length);
@@ -705,7 +748,7 @@ var Channel = (function () {
             var _iteratorError = undefined;
 
             try {
-                for (var _iterator = _getIterator(arr), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+                for (var _iterator = arr[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
                     var val = _step.value;
 
                     ch.buf.push(val);
@@ -730,42 +773,25 @@ var Channel = (function () {
         }
     }, {
         key: 'close',
-
-        /*
-            Marks a channel to no longer be writable.
-             Accepts an optional boolean `all`, to signify
-            whether or not to close the entire pipeline.
-        */
         value: function close(ch) {
-            var all = arguments[1] === undefined ? false : arguments[1];
+            var all = arguments.length <= 1 || arguments[1] === undefined ? false : arguments[1];
 
             ch.state = STATES.CLOSED;
             if (all) ch[SHOULD_CLOSE] = true;
             setTimeout(function () {
                 return slide(ch);
-            }); // we have a timing problem with pipes.. this resolves it, but is hacky.
+            });
         }
     }, {
         key: 'empty',
-
-        /*
-            Determines if a channel
-            has any values left for `take` to use.
-        */
         value: function empty(ch) {
             if (ch.buf) return ch.buf.empty() && ch.puts.empty();
             return ch.puts.empty();
         }
     }, {
         key: 'put',
-
-        /*
-            Places a new value onto the provided channel.
-             If the buffer is full, the promise will be pushed
-            onto Channel.puts to be resolved when buffer space is available.
-        */
         value: function put(ch, val) {
-            return new _Promise(function (resolve) {
+            return new Promise(function (resolve) {
                 if (ch.state !== STATES.OPEN) return resolve(ACTIONS.DONE);
                 var put = wrap(val, ch.transform, resolve);
                 ch.puts.push(put);
@@ -774,14 +800,8 @@ var Channel = (function () {
         }
     }, {
         key: 'take',
-
-        /*
-            Takes the first value from the provided channel.
-             If no value is provided, the promise will be pushed
-            onto Channel.takes to be resolved when a value is available.
-        */
         value: function take(ch) {
-            return new _Promise(function (resolve) {
+            return new Promise(function (resolve) {
                 if (ch.state === STATES.ENDED) return resolve(ACTIONS.DONE);
                 ch.takes.push(resolve);
                 slide(ch);
@@ -790,7 +810,7 @@ var Channel = (function () {
     }, {
         key: 'tail',
         value: function tail(ch, val) {
-            return new _Promise(function (resolve) {
+            return new Promise(function (resolve) {
                 if (ch.state !== STATES.OPEN) return resolve(ACTIONS.DONE);
                 var tail = wrap(val, ch.transform, resolve);
                 ch.tails.push(tail);
@@ -799,14 +819,9 @@ var Channel = (function () {
         }
     }, {
         key: 'produce',
-
-        /*
-            Helper method for putting values onto a channel
-            from a provided producer whenever there is space.
-        */
         value: function produce(ch, producer) {
             var spin;
-            return _regeneratorRuntime.async(function produce$(context$2$0) {
+            return regeneratorRuntime.async(function produce$(context$2$0) {
                 var _this4 = this;
 
                 while (1) switch (context$2$0.prev = context$2$0.next) {
@@ -815,7 +830,7 @@ var Channel = (function () {
 
                         (function callee$2$0() {
                             var val, r;
-                            return _regeneratorRuntime.async(function callee$2$0$(context$3$0) {
+                            return regeneratorRuntime.async(function callee$2$0$(context$3$0) {
                                 while (1) switch (context$3$0.prev = context$3$0.next) {
                                     case 0:
                                         context$3$0.prev = 0;
@@ -828,13 +843,13 @@ var Channel = (function () {
 
                                         val = producer();
 
-                                        if (!(val instanceof _Promise)) {
+                                        if (!(val instanceof Promise)) {
                                             context$3$0.next = 9;
                                             break;
                                         }
 
                                         context$3$0.next = 6;
-                                        return _regeneratorRuntime.awrap(val);
+                                        return regeneratorRuntime.awrap(val);
 
                                     case 6:
                                         val = context$3$0.sent;
@@ -843,11 +858,11 @@ var Channel = (function () {
 
                                     case 9:
                                         context$3$0.next = 11;
-                                        return _regeneratorRuntime.awrap(timeout());
+                                        return regeneratorRuntime.awrap(timeout());
 
                                     case 11:
                                         context$3$0.next = 13;
-                                        return _regeneratorRuntime.awrap(Channel.put(ch, val));
+                                        return regeneratorRuntime.awrap(Channel.put(ch, val));
 
                                     case 13:
                                         r = context$3$0.sent;
@@ -891,15 +906,9 @@ var Channel = (function () {
         }
     }, {
         key: 'consume',
-
-        /*
-            Helper method for executing a provided consumer
-            each time a channel value is available.
-        */
         value: function consume(ch) {
-            var consumer = arguments[1] === undefined ? function () {} // noop default
-            : arguments[1];
-            return _regeneratorRuntime.async(function consume$(context$2$0) {
+            var consumer = arguments.length <= 1 || arguments[1] === undefined ? function () {} : arguments[1];
+            return regeneratorRuntime.async(function consume$(context$2$0) {
                 var _this5 = this;
 
                 while (1) switch (context$2$0.prev = context$2$0.next) {
@@ -907,7 +916,7 @@ var Channel = (function () {
                         ch[IS_CONSUMING] = true;
                         (function callee$2$0() {
                             var taking, val, consuming;
-                            return _regeneratorRuntime.async(function callee$2$0$(context$3$0) {
+                            return regeneratorRuntime.async(function callee$2$0$(context$3$0) {
                                 while (1) switch (context$3$0.prev = context$3$0.next) {
                                     case 0:
                                         taking = Channel.take(ch);
@@ -919,7 +928,7 @@ var Channel = (function () {
                                         }
 
                                         context$3$0.next = 4;
-                                        return _regeneratorRuntime.awrap(taking);
+                                        return regeneratorRuntime.awrap(taking);
 
                                     case 4:
                                         val = context$3$0.sent;
@@ -936,7 +945,7 @@ var Channel = (function () {
 
                                         taking = Channel.take(ch);
                                         context$3$0.next = 11;
-                                        return _regeneratorRuntime.awrap(consuming);
+                                        return regeneratorRuntime.awrap(consuming);
 
                                     case 11:
                                         context$3$0.next = 1;
@@ -951,7 +960,7 @@ var Channel = (function () {
                                         }
 
                                         context$3$0.next = 17;
-                                        return _regeneratorRuntime.awrap(ch[IS_FLUSHING]);
+                                        return regeneratorRuntime.awrap(ch[IS_FLUSHING]);
 
                                     case 17:
                                         context$3$0.next = 20;
@@ -975,36 +984,21 @@ var Channel = (function () {
         }
     }, {
         key: 'done',
-
-        /*
-            Registers a promise to be resolved
-            when the channel has fully ended.
-        */
         value: function done(ch) {
-            return new _Promise(function (resolve) {
+            return new Promise(function (resolve) {
                 if (ch.state === STATES.ENDED) return resolve();
                 ch.waiting.push(resolve);
             });
         }
     }, {
         key: 'pipeline',
-
-        /*
-            Automatically builds a set of channels
-            for the provided function arguments,
-            setting up a pipe from the first channel
-            all the way down to the last channel.
-             Returns references to both
-            the first and the last channel.
-        */
         value: function pipeline() {
-            var first = null;
-            var last = null;
-
             for (var _len4 = arguments.length, args = Array(_len4), _key4 = 0; _key4 < _len4; _key4++) {
                 args[_key4] = arguments[_key4];
             }
 
+            var first = null;
+            var last = null;
             if (args.length === 0) {
                 first = new Channel();
                 last = first;
@@ -1022,8 +1016,6 @@ var Channel = (function () {
             }
             return [first, last];
         }
-    }, {
-        key: 'pipe',
 
         /*
             Builds a pipeline from a parent channel
@@ -1034,6 +1026,8 @@ var Channel = (function () {
              do NOT bubble up to the user yet in nodejs.
              will be fixed in the future, supposedly).
         */
+    }, {
+        key: 'pipe',
         value: function pipe(parent) {
             var _parent$pipeline,
                 _this7 = this;
@@ -1049,18 +1043,18 @@ var Channel = (function () {
                     (function callee$3$0() {
                         var _loop3, _iteratorNormalCompletion2, _didIteratorError2, _iteratorError2, _iterator2, _step2, _ret9;
 
-                        return _regeneratorRuntime.async(function callee$3$0$(context$4$0) {
+                        return regeneratorRuntime.async(function callee$3$0$(context$4$0) {
                             var _this6 = this;
 
                             while (1) switch (context$4$0.prev = context$4$0.next) {
                                 case 0:
                                     _loop3 = function callee$4$0() {
                                         var val, channel;
-                                        return _regeneratorRuntime.async(function callee$4$0$(context$5$0) {
+                                        return regeneratorRuntime.async(function callee$4$0$(context$5$0) {
                                             while (1) switch (context$5$0.prev = context$5$0.next) {
                                                 case 0:
                                                     context$5$0.next = 2;
-                                                    return _regeneratorRuntime.awrap(parent.take());
+                                                    return regeneratorRuntime.awrap(parent.take());
 
                                                 case 2:
                                                     val = context$5$0.sent;
@@ -1080,7 +1074,7 @@ var Channel = (function () {
                                                     _iteratorError2 = undefined;
                                                     context$5$0.prev = 8;
 
-                                                    for (_iterator2 = _getIterator(parent.pipeline); !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                                                    for (_iterator2 = parent.pipeline[Symbol.iterator](); !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
                                                         channel = _step2.value;
 
                                                         channel.close(true);
@@ -1122,7 +1116,7 @@ var Channel = (function () {
 
                                                 case 25:
                                                     context$5$0.next = 27;
-                                                    return _regeneratorRuntime.awrap(_Promise.all(parent.pipeline.map(function (x) {
+                                                    return regeneratorRuntime.awrap(Promise.all(parent.pipeline.map(function (x) {
                                                         return x.put(val);
                                                     })));
 
@@ -1140,7 +1134,7 @@ var Channel = (function () {
                                     }
 
                                     context$4$0.next = 4;
-                                    return _regeneratorRuntime.awrap(_loop3());
+                                    return regeneratorRuntime.awrap(_loop3());
 
                                 case 4:
                                     _ret9 = context$4$0.sent;
@@ -1162,6 +1156,7 @@ var Channel = (function () {
                             }
                         }, null, _this7);
                     })();
+                    // eslint-disable-line no-loop-func
                     parent[ACTIONS.CANCEL] = function () {
                         running = false;
                     };
@@ -1171,10 +1166,6 @@ var Channel = (function () {
         }
     }, {
         key: 'merge',
-
-        /*
-            Pipes all provided channels into a new, single destination.
-        */
         value: function merge() {
             var child = new Channel();
             var _iteratorNormalCompletion3 = true;
@@ -1186,7 +1177,7 @@ var Channel = (function () {
                     channels[_key6] = arguments[_key6];
                 }
 
-                for (var _iterator3 = _getIterator(channels), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+                for (var _iterator3 = channels[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
                     var _parent = _step3.value;
 
                     _parent.pipe(child);
@@ -1216,7 +1207,11 @@ var Channel = (function () {
             var _iteratorError4 = undefined;
 
             try {
-                for (var _iterator4 = _getIterator(_Array$entries(parent.pipeline)), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+                for (var _len7 = arguments.length, channels = Array(_len7 > 1 ? _len7 - 1 : 0), _key7 = 1; _key7 < _len7; _key7++) {
+                    channels[_key7 - 1] = arguments[_key7];
+                }
+
+                for (var _iterator4 = Array.entries(parent.pipeline)[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
                     var _step4$value = _slicedToArray(_step4.value, 2);
 
                     var index = _step4$value[0];
@@ -1226,11 +1221,7 @@ var Channel = (function () {
                     var _iteratorError5 = undefined;
 
                     try {
-                        for (var _len7 = arguments.length, channels = Array(_len7 > 1 ? _len7 - 1 : 0), _key7 = 1; _key7 < _len7; _key7++) {
-                            channels[_key7 - 1] = arguments[_key7];
-                        }
-
-                        for (var _iterator5 = _getIterator(channels), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
+                        for (var _iterator5 = channels[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
                             var ch2 = _step5.value;
 
                             if (pipe === ch2) parent.pipeline.splice(index, 1);
@@ -1279,7 +1270,6 @@ Channel.DONE = ACTIONS.DONE; // expose this so loops can listen for it
 
 // this error is never expected to be thrown
 // just a sanity check during development
-// need a way to empty out the list
 
 // A List containing any puts which could not be placed directly onto the buffer
 
@@ -1293,4 +1283,4 @@ Channel.DONE = ACTIONS.DONE; // expose this so loops can listen for it
 // from one channel to multiple others.
 
 // An optional array of promises, to be resolved when the channel is marked as finished.
-// eslint-disable-line no-loop-func
+// noop default

--- a/dist/data-structures.js
+++ b/dist/data-structures.js
@@ -1,26 +1,19 @@
-'use strict';
-
-var _createClass = require('babel-runtime/helpers/create-class')['default'];
-
-var _classCallCheck = require('babel-runtime/helpers/class-call-check')['default'];
-
-var _inherits = require('babel-runtime/helpers/inherits')['default'];
-
-var _get = require('babel-runtime/helpers/get')['default'];
-
-var _toConsumableArray = require('babel-runtime/helpers/to-consumable-array')['default'];
-
-var _Symbol$iterator = require('babel-runtime/core-js/symbol/iterator')['default'];
-
-var _getIterator = require('babel-runtime/core-js/get-iterator')['default'];
-
-var _Symbol$toStringTag = require('babel-runtime/core-js/symbol/to-string-tag')['default'];
-
-var _Object$create = require('babel-runtime/core-js/object/create')['default'];
+"use strict";
 
 Object.defineProperty(exports, '__esModule', {
     value: true
 });
+
+var _get = function get(_x3, _x4, _x5) { var _again = true; _function: while (_again) { var object = _x3, property = _x4, receiver = _x5; _again = false; if (object === null) object = Function.prototype; var desc = Object.getOwnPropertyDescriptor(object, property); if (desc === undefined) { var parent = Object.getPrototypeOf(object); if (parent === null) { return undefined; } else { _x3 = parent; _x4 = property; _x5 = receiver; _again = true; desc = parent = undefined; continue _function; } } else if ('value' in desc) { return desc.value; } else { var getter = desc.get; if (getter === undefined) { return undefined; } return getter.call(receiver); } } };
+
+var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ('value' in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
+
+function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr2 = Array(arr.length); i < arr.length; i++) arr2[i] = arr[i]; return arr2; } else { return Array.from(arr); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
 var MAX_SIZE = 4096;
 
 // can be swapped to symbols to make more 'private'
@@ -37,10 +30,12 @@ var Data = (function () {
         this[ARR] = [];
     }
 
+    // Data[Symbol.toStringTag] = 'Data';
+
     _createClass(Data, [{
-        key: _Symbol$iterator,
+        key: Symbol.iterator,
         value: function value() {
-            return _getIterator(this[ARR]); // should be overridden for stacks, so we iterate from back to front
+            return this[ARR][Symbol.iterator](); // should be overridden for stacks, so we iterate from back to front
         }
     }, {
         key: 'flush',
@@ -63,7 +58,7 @@ var Data = (function () {
             return [].concat(_toConsumableArray(this[ARR]));
         }
     }, {
-        key: _Symbol$toStringTag,
+        key: Symbol.toStringTag,
         get: function get() {
             return 'Data';
         }
@@ -75,23 +70,21 @@ var Data = (function () {
     }], [{
         key: 'construct',
         value: function construct() {
-            return _Object$create(this.constructor);
+            return Object.create(this.constructor);
         }
     }]);
 
     return Data;
 })();
 
-// Data[Symbol.toStringTag] = 'Data';
-
 var Stack = (function (_Data) {
+    _inherits(Stack, _Data);
+
     function Stack() {
         _classCallCheck(this, Stack);
 
         _get(Object.getPrototypeOf(Stack.prototype), 'constructor', this).call(this);
     }
-
-    _inherits(Stack, _Data);
 
     _createClass(Stack, [{
         key: 'push',
@@ -109,7 +102,7 @@ var Stack = (function (_Data) {
             return this[ARR][this.length - 1];
         }
     }, {
-        key: _Symbol$toStringTag,
+        key: Symbol.toStringTag,
         get: function get() {
             return 'Stack';
         }
@@ -121,16 +114,16 @@ var Stack = (function (_Data) {
 exports.Stack = Stack;
 
 var FixedStack = (function (_Stack) {
+    _inherits(FixedStack, _Stack);
+
     function FixedStack() {
-        var size = arguments[0] === undefined ? MAX_SIZE : arguments[0];
+        var size = arguments.length <= 0 || arguments[0] === undefined ? MAX_SIZE : arguments[0];
 
         _classCallCheck(this, FixedStack);
 
         _get(Object.getPrototypeOf(FixedStack.prototype), 'constructor', this).call(this);
         this[SIZE] = size;
     }
-
-    _inherits(FixedStack, _Stack);
 
     _createClass(FixedStack, [{
         key: 'push',
@@ -143,7 +136,7 @@ var FixedStack = (function (_Stack) {
             return this.length >= this[SIZE];
         }
     }, {
-        key: _Symbol$toStringTag,
+        key: Symbol.toStringTag,
         get: function get() {
             return 'FixedStack';
         }
@@ -160,13 +153,13 @@ var FixedStack = (function (_Stack) {
 exports.FixedStack = FixedStack;
 
 var Queue = (function (_Data2) {
+    _inherits(Queue, _Data2);
+
     function Queue() {
         _classCallCheck(this, Queue);
 
         _get(Object.getPrototypeOf(Queue.prototype), 'constructor', this).call(this);
     }
-
-    _inherits(Queue, _Data2);
 
     _createClass(Queue, [{
         key: 'push',
@@ -184,7 +177,7 @@ var Queue = (function (_Data2) {
             return this[ARR][0];
         }
     }, {
-        key: _Symbol$toStringTag,
+        key: Symbol.toStringTag,
         get: function get() {
             return 'Queue';
         }
@@ -196,13 +189,13 @@ var Queue = (function (_Data2) {
 exports.Queue = Queue;
 
 var List = (function (_Queue) {
+    _inherits(List, _Queue);
+
     function List() {
         _classCallCheck(this, List);
 
         _get(Object.getPrototypeOf(List.prototype), 'constructor', this).call(this);
     }
-
-    _inherits(List, _Queue);
 
     _createClass(List, [{
         key: 'unshift',
@@ -212,7 +205,7 @@ var List = (function (_Queue) {
             return (_ARR = this[ARR]).unshift.apply(_ARR, arguments);
         }
     }, {
-        key: _Symbol$toStringTag,
+        key: Symbol.toStringTag,
         get: function get() {
             return 'List';
         }
@@ -224,16 +217,16 @@ var List = (function (_Queue) {
 exports.List = List;
 
 var FixedQueue = (function (_Queue2) {
+    _inherits(FixedQueue, _Queue2);
+
     function FixedQueue() {
-        var size = arguments[0] === undefined ? MAX_SIZE : arguments[0];
+        var size = arguments.length <= 0 || arguments[0] === undefined ? MAX_SIZE : arguments[0];
 
         _classCallCheck(this, FixedQueue);
 
         _get(Object.getPrototypeOf(FixedQueue.prototype), 'constructor', this).call(this);
         this[SIZE] = size;
     }
-
-    _inherits(FixedQueue, _Queue2);
 
     _createClass(FixedQueue, [{
         key: 'push',
@@ -255,7 +248,7 @@ var FixedQueue = (function (_Queue2) {
             return (_ARR2 = this[ARR]).unshift.apply(_ARR2, arguments);
         }
     }, {
-        key: _Symbol$toStringTag,
+        key: Symbol.toStringTag,
         get: function get() {
             return 'FixedQueue';
         }

--- a/package.json
+++ b/package.json
@@ -43,6 +43,5 @@
     "zana-assert": "^0.1.4"
   },
   "dependencies": {
-    "babel-runtime": "^5.7.0"
   }
 }


### PR DESCRIPTION
This is just for reference, but for some reason Meteor's new ES2015 `modules` package (in Meteor 1.3 Beta) won't import `babel-runtime`, so as a temporary workaround I disabled the runtime so that the symbols are defined inline.