### PR TITLE
refactor: remove excessive code from channel implementation

### DIFF
--- a/src/channel.js
+++ b/src/channel.js
@@ -177,11 +177,6 @@ async function _bufferedSlide(ch: Channel) {
                 take(val);
             }
         }
-        if (!ch.puts.empty() && !ch.buf.full()) {
-            let put = ch.puts.shift();
-            ch.buf.push(put);
-            put.resolve();
-        }
     }
     while (!ch.puts.empty() && !ch.buf.full()) {
         let put = ch.puts.shift();


### PR DESCRIPTION
I've left single commit with code removal here bevause sliding conditions were overcomplicated even in my versions. 

In my opinion, you should support only buffered sliding and remove everything else alltogether because those "similar but not exact" parallel code stacks (`_bufferedSlide` vs `_slide`...) is a bad sign.

And that's obviously not something I can "fix". 